### PR TITLE
queue locks are so 2020

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,4 +2,4 @@ module github.com/ThePrimeagen/tyrone-biggums
 
 go 1.18
 
-require github.com/gorilla/websocket v1.4.2 // indirect
+require github.com/gorilla/websocket v1.4.2

--- a/go/pkg/game_loop/game_queue_test.go
+++ b/go/pkg/game_loop/game_queue_test.go
@@ -9,54 +9,53 @@ import (
 )
 
 func testMessage(t *testing.T, queue *gameloop.GameQueue, froms []uint) {
+	messages := queue.Flush()
 
-    messages := queue.Flush()
+	if len(messages) != len(froms) {
+		t.Errorf("Expected to have %v messages, but got %v messages", len(froms), len(messages))
+	}
 
-    if len(messages) != len(froms) {
-        t.Errorf("Expected to have %v messages, but got %v messages", len(froms), len(messages))
-    }
+	for i, message := range messages {
+		if message.From != froms[i] {
+			t.Errorf("Expected a message From 1 but got %v", message.From)
+		}
+	}
 
-    for i, message := range messages {
-        if message.From != froms[i] {
-            t.Errorf("Expected a message From 1 but got %v", message.From)
-        }
-    }
-
-    messages = queue.Flush()
-    if messages != nil {
-        t.Errorf("Expecting the queue to be empty but got %v messages", len(messages))
-    }
+	messages = queue.Flush()
+	if messages != nil {
+		t.Errorf("Expecting the queue to be empty but got %v messages", len(messages))
+	}
 }
 
 func TestGameQueue(t *testing.T) {
-    queue := gameloop.NewQueue()
-    s1 := newSocket()
-    s2 := newSocket()
+	s1 := newSocket()
+	s2 := newSocket()
+	queue := gameloop.NewQueue(s1, s2)
 
-    queue.Start(s1, s2)
+	queue.Start()
 
-    msgs := queue.Flush()
-    if msgs != nil {
-        t.Errorf("Expected to have no messages when flushed %+v", msgs)
-    }
+	msgs := queue.Flush()
+	if msgs != nil {
+		t.Errorf("Expected to have no messages when flushed %+v", msgs)
+	}
 
-    // TODO: What are good ways to ensure that this runs properly?
-    // What i don't want to do is add stuff to the queue
-    //
-    // Perhaps (probably not if we are real here) I could make the socket have
-    // some sort of fan out where I can listen to make sure that the channel
-    // has been sent the message before proceeding instead of using 1 ms
-    // timeout.
-    s1.inBound <- server.CreateMessage(server.Fire)
-    time.Sleep(time.Millisecond)
-    testMessage(t, queue, []uint{1})
+	// TODO: What are good ways to ensure that this runs properly?
+	// What i don't want to do is add stuff to the queue
+	//
+	// Perhaps (probably not if we are real here) I could make the socket have
+	// some sort of fan out where I can listen to make sure that the channel
+	// has been sent the message before proceeding instead of using 1 ms
+	// timeout.
+	s1.inBound <- server.CreateMessage(server.Fire)
+	time.Sleep(time.Millisecond)
+	testMessage(t, queue, []uint{1})
 
-    s2.inBound <- server.CreateMessage(server.Fire)
-    time.Sleep(time.Millisecond)
-    testMessage(t, queue, []uint{2})
+	s2.inBound <- server.CreateMessage(server.Fire)
+	time.Sleep(time.Millisecond)
+	testMessage(t, queue, []uint{2})
 
-    s2.inBound <- server.CreateMessage(server.Fire)
-    s1.inBound <- server.CreateMessage(server.Fire)
-    time.Sleep(time.Millisecond)
-    testMessage(t, queue, []uint{2, 1})
+	s2.inBound <- server.CreateMessage(server.Fire)
+	s1.inBound <- server.CreateMessage(server.Fire)
+	time.Sleep(time.Millisecond)
+	testMessage(t, queue, []uint{2, 1})
 }

--- a/go/pkg/memqueue/queue.go
+++ b/go/pkg/memqueue/queue.go
@@ -1,0 +1,77 @@
+package memqueue
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// Lock free
+type MemQueue[T any] struct {
+	head unsafe.Pointer
+	tail unsafe.Pointer
+}
+
+type node[T any] struct {
+	value T
+	next  unsafe.Pointer
+}
+
+// New creates a queue with dummy node.
+func NewMemQueue[T any]() *MemQueue[T] {
+	node := unsafe.Pointer(new(node[T]))
+	return &MemQueue[T]{
+		head: node,
+		tail: node,
+	}
+}
+
+// Enqueue push back the given value v to queue.
+func (q *MemQueue[T]) Enqueue(v T) {
+	node := &node[T]{value: v}
+	for {
+		tail := load[T](&q.tail)
+		next := load[T](&tail.next)
+		if tail == load[T](&q.tail) {
+			if next == nil {
+				if cas(&tail.next, next, node) {
+					cas(&q.tail, tail, node)
+					return
+				}
+			} else {
+				cas(&q.tail, tail, next)
+			}
+		}
+	}
+}
+
+// Dequeue pop front a value from queue
+func (q *MemQueue[T]) Dequeue() (v T, ok bool) {
+	for {
+		head := load[T](&q.head)
+		tail := load[T](&q.tail)
+		next := load[T](&head.next)
+		if head == load[T](&q.head) {
+			if head == tail {
+				if next == nil {
+					var zero T
+					return zero, false
+				}
+				cas(&q.tail, tail, next)
+			} else {
+				v := next.value
+				if cas(&q.head, head, next) {
+					return v, true
+				}
+			}
+		}
+	}
+}
+
+func load[T any](p *unsafe.Pointer) *node[T] {
+	return (*node[T])(atomic.LoadPointer(p))
+}
+
+func cas[T any](p *unsafe.Pointer, old, new *node[T]) bool {
+	return atomic.CompareAndSwapPointer(p,
+		unsafe.Pointer(old), unsafe.Pointer(new))
+}


### PR DESCRIPTION
removes the sync.mutex out of the message queue in favor of a lock less concurrent safe queue. 

go fmt on the master branch seems out of date or something as go fmt [now](https://go.dev/src/cmd/gofmt/doc.go) forces tabs. Merge #12  first to see actual changes. Or hit that [ignore whitespace diff button](https://github.com/ThePrimeagen/tyrone-biggums/pull/13/files?w=1)

I think this in memory queue is faster than channels, but it doesn't block so it would require more refactoring likely with sleeps to handle an empty queue in order to replace all the channels with the queue implementation. This is very useful in real world environments where the queue is rarely starved. If the sleeps aren't tuned right and the queue was starved it would add latency over the channel implementation, however under significant load the queue would never starve and be faster than channels.